### PR TITLE
Upgrade date-fns 2.x → 4.x

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,10 @@ Website for the Art School of Shlisselburg ([art.shlisselburg.org](https://art.s
 
 Node 22 required (see `mise.toml`). Deployed on Vercel.
 
+## Git Workflow
+
+Feature branches are named `issue-XXX` where `XXX` is the related GitHub issue number.
+
 ## Code Style
 
 ESLint 9 flat config (`eslint.config.js`) using `FlatCompat` from `@eslint/eslintrc` to bridge `eslint-config-next` (which doesn't support native flat config in Next.js 15.x). Extends `next/core-web-vitals`. Enforces: no semicolons, double quotes, 4-space indentation, always-multiline trailing commas, `eol-last`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@radix-ui/react-tooltip": "^1.0.0",
                 "classnames": "^2.2.6",
                 "dangerously-set-html-content": "^1.0.13",
-                "date-fns": "^2.29.0",
+                "date-fns": "^4.0.0",
                 "markdown-it": "^13.0.1",
                 "next": "^15.5.0",
                 "next-seo": "^5.15.0",
@@ -2868,15 +2868,13 @@
             }
         },
         "node_modules/date-fns": {
-            "version": "2.29.3",
-            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
-            "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
-            "engines": {
-                "node": ">=0.11"
-            },
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+            "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+            "license": "MIT",
             "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/date-fns"
+                "type": "github",
+                "url": "https://github.com/sponsors/kossnocorp"
             }
         },
         "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "@radix-ui/react-tooltip": "^1.0.0",
         "classnames": "^2.2.6",
         "dangerously-set-html-content": "^1.0.13",
-        "date-fns": "^2.29.0",
+        "date-fns": "^4.0.0",
         "markdown-it": "^13.0.1",
         "next": "^15.5.0",
         "next-seo": "^5.15.0",

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,4 +1,4 @@
-import format from "date-fns/format"
+import { format } from "date-fns/format"
 import { ru } from "date-fns/locale"
 
 /**


### PR DESCRIPTION
## Summary
- Upgraded `date-fns` from 2.29.3 to 4.1.0
- Fixed import in `src/lib/date.ts`: default export → named export (`import { format }`) for v4 compatibility
- No other code changes needed — the locale import was already compatible

Closes #232